### PR TITLE
Fix bug : get spooler state by FQDN not working but by ip it working

### DIFF
--- a/Recon/Get-SpoolerStatus.ps1
+++ b/Recon/Get-SpoolerStatus.ps1
@@ -120,6 +120,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
 using System.Text;
+using System.Net;
+
 namespace PingCastle
 {
     public class rprn
@@ -811,6 +813,9 @@ namespace PingCastle
             DEVMODE_CONTAINER devmodeContainer = new DEVMODE_CONTAINER();
             try
             {
+                if(Uri.CheckHostName(computer).ToString() == "Dns" ){
+                    computer = Dns.GetHostAddresses(computer)[0].ToString();
+                }
                 Int32 ret = RpcOpenPrinter("\\\\" + computer, out hHandle, null, ref devmodeContainer, 0);
                 if (ret == 0)
                 {


### PR DESCRIPTION
exemple of bug :
```powershell
Envoi d’une requête 'ping' sur windomain.local [10.13.3.69] avec 32 octets de données :
Réponse de 10.13.3.69 : octets=32 temps<1ms TTL=128
Réponse de 10.13.3.69 : octets=32 temps<1ms TTL=128
Réponse de 10.13.3.69 : octets=32 temps<1ms TTL=128
Réponse de 10.13.3.69 : octets=32 temps<1ms TTL=128

Statistiques Ping pour 10.13.3.69:
    Paquets : envoyés = 4, reçus = 4, perdus = 0 (perte 0%),
Durée approximative des boucles en millisecondes :
    Minimum = 0ms, Maximum = 0ms, Moyenne = 0ms
PS C:\> Get-SpoolerStatus -ComputerName 10.13.3.69

ComputerName SpoolerStatus
------------ -------------
10.13.3.69           True


PS C:\> Get-SpoolerStatus -ComputerName windomain.local

ComputerName    SpoolerStatus
------------    -------------
windomain.local         False

```

fix mehod : check if computername is an ip else script convert FQDN to an IP